### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "meistertr.smarthome@gmail.com"
   },
   "engines": {
-    "node": ">=14.5.0"
+    "node": ">=16"
   },
   "contributors": [
     {


### PR DESCRIPTION
adapter-code 3.x.x is know to fail with node 14 as npm 6 does nozt instal peer dependencies. So this adapter requires node 16 or newer